### PR TITLE
Implement role-aware Firestore search support

### DIFF
--- a/frontend/src/pages/pc/adminInprogress/index.jsx
+++ b/frontend/src/pages/pc/adminInprogress/index.jsx
@@ -37,17 +37,23 @@ const AdminInprogress = () => {
   const navigate = useNavigate();
 
   // 获取表单列表数据
-  const fetchFormList = async () => {
+  const fetchFormList = async (override = {}) => {
     try {
       setLoading(true);
       const status = statusFilter === 'All' ? "draft,pending,declined" : statusFilter.toLowerCase();
-      const response = await getFormList({
+      const pageParam = override.page ?? currentPage;
+      const sizeParam = override.pageSize ?? pageSize;
+      const formNameFilter = override.qFormName ?? searchFormName;
+
+      const params = {
         status,
-        page: currentPage,
-        pageSize,
+        page: pageParam,
+        pageSize: sizeParam,
         // 将搜索词（表单名）传给后端做前缀匹配
-        qFormName: (searchFormName || '').trim()
-      });
+        qFormName: formNameFilter
+      };
+
+      const response = await getFormList(params);
 
       if (response) {
         const items = response.items || [];
@@ -126,7 +132,10 @@ const AdminInprogress = () => {
             placeholder="Search inspections..."
             value={searchFormName}
             onChange={(e) => setSearchFormName(e.target.value)}
-            onSearch={() => fetchFormList()}
+            onSearch={() => {
+              setCurrentPage(1);
+              fetchFormList({ page: 1, qFormName: searchFormName });
+            }}
             className={styles.searchInput}
             prefix={<SearchOutlined />}
           />

--- a/frontend/src/pages/pc/reviewedList/index.jsx
+++ b/frontend/src/pages/pc/reviewedList/index.jsx
@@ -34,18 +34,30 @@ const ReviewedList = () => {
   const [formTemplates, setFormTemplates] = useState([]);
 
   // Get reviewed form list data
-  const fetchReviewedList = async () => {
+  const fetchReviewedList = async (override = {}) => {
     try {
       setLoading(true);
-      // TODO: need to include declined forms in the future 
-      const response = await getFormList({
+      // TODO: need to include declined forms in the future
+      const pageParam = override.page ?? currentPage;
+      const sizeParam = override.pageSize ?? pageSize;
+      const inspectorFilter = override.qInspector ?? searchInspectors;
+      const formNameFilter = override.qFormName ?? searchFormName;
+
+      const params = {
         status: 'approved',
-        page: currentPage,
-        pageSize,
-        viewMode: 'reviewer',
-        qQnspector: searchInspectors,
-        qFormName: searchFormName
-      });
+        page: pageParam,
+        pageSize: sizeParam,
+        viewMode: 'reviewer'
+      };
+
+      if (typeof inspectorFilter === 'string' && inspectorFilter.trim()) {
+        params.qInspector = inspectorFilter.trim();
+      }
+      if (typeof formNameFilter === 'string' && formNameFilter.trim()) {
+        params.qFormName = formNameFilter.trim();
+      }
+
+      const response = await getFormList(params);
 
       if (response) {
         const items = response.items || [];
@@ -92,10 +104,8 @@ const ReviewedList = () => {
   const paginatedData = filteredData;
 
   const handleSearch = () => {
-    // Reset to first page when searching
     setCurrentPage(1);
-    // Trigger data fetch with current search parameters
-    fetchReviewedList();
+    fetchReviewedList({ page: 1 });
   };
 
   const handleReset = () => {
@@ -103,9 +113,7 @@ const ReviewedList = () => {
     setSearchFormName(undefined);
     setCurrentPage(1);
     // Trigger search after reset
-    setTimeout(() => {
-      fetchReviewedList();
-    }, 0);
+    fetchReviewedList({ page: 1, qInspector: '', qFormName: '' });
   };
 
   const handlePageChange = (page, size) => {

--- a/frontend/src/pages/pc/toReviewList/index.jsx
+++ b/frontend/src/pages/pc/toReviewList/index.jsx
@@ -32,17 +32,29 @@ const ToReviewList = () => {
   const [formTemplates, setFormTemplates] = useState([]);
 
   // Get pending review form list data
-  const fetchToReviewList = async () => {
+  const fetchToReviewList = async (override = {}) => {
     try {
       setLoading(true);
-      const response = await getFormList({
+      const pageParam = override.page ?? currentPage;
+      const sizeParam = override.pageSize ?? pageSize;
+      const inspectorFilter = override.qInspector ?? searchInspectors;
+      const formNameFilter = override.qFormName ?? searchFormName;
+
+      const params = {
         status: 'pending',
-        page: currentPage,
-        pageSize,
-        viewMode: 'reviewer',
-        qInspector: searchInspectors,
-        qFormName:  searchFormName        
-      });
+        page: pageParam,
+        pageSize: sizeParam,
+        viewMode: 'reviewer'
+      };
+
+      if (typeof inspectorFilter === 'string' && inspectorFilter.trim()) {
+        params.qInspector = inspectorFilter.trim();
+      }
+      if (typeof formNameFilter === 'string' && formNameFilter.trim()) {
+        params.qFormName = formNameFilter.trim();
+      }
+
+      const response = await getFormList(params);
 
       if (response) {
         const items = response.items || [];
@@ -81,10 +93,8 @@ const ToReviewList = () => {
   const paginatedData = filteredData;
 
   const handleSearch = () => {
-    // Reset to first page when searching
     setCurrentPage(1);
-    // Trigger data fetch with current search parameters
-    fetchToReviewList();
+    fetchToReviewList({ page: 1 });
   };
 
   const handleReset = () => {
@@ -92,9 +102,7 @@ const ToReviewList = () => {
     setSearchFormName(undefined);
     setCurrentPage(1);
     // Trigger search after reset
-    setTimeout(() => {
-      fetchToReviewList();
-    }, 0);
+    fetchToReviewList({ page: 1, qInspector: '', qFormName: '' });
   };
 
   const handlePageChange = (page, size) => {

--- a/frontend/src/services/form-service.js
+++ b/frontend/src/services/form-service.js
@@ -99,8 +99,15 @@ export const getFormList = async (params = {}) => {
       viewMode
     };
     // 统一改为后端识别的字段；同时兼容调用方传入的新旧字段名
-    if (qInspector ?? inspector) queryParams.qInspector = (qInspector ?? inspector);
-    if (qFormName  ?? formName)  queryParams.qFormName  = (qFormName  ?? formName);
+    const inspectorFilter = qInspector ?? inspector;
+    const formNameFilter = qFormName ?? formName;
+
+    if (typeof inspectorFilter === 'string' && inspectorFilter.trim()) {
+      queryParams.qInspector = inspectorFilter.trim();
+    }
+    if (typeof formNameFilter === 'string' && formNameFilter.trim()) {
+      queryParams.qFormName = formNameFilter.trim();
+    }
 
     const response = await http.get('/form/form-list', queryParams);
     return response.data;


### PR DESCRIPTION
- add Firestore prefix-search ordering that respects user roles and avoids in-memory filtering in `getFormList`
- normalize and trim search params before issuing requests from the web clients
- hook PC and mobile search inputs up to backend filtering instead of local filtering
